### PR TITLE
Fix chapter loading logic for early save file

### DIFF
--- a/src/com/accounting/view/GameProgressManager.java
+++ b/src/com/accounting/view/GameProgressManager.java
@@ -64,7 +64,7 @@ public class GameProgressManager {
             return -1; // No saved progress
         }
 
-        int highestChapter = 0;
+        int highestChapter = -1;
 
         // Loop through saved data to find the highest unlocked chapter
         for (String key : progressData.keySet()) {
@@ -80,6 +80,6 @@ public class GameProgressManager {
             }
         }
 
-        return (highestChapter > 0) ? highestChapter + 1 : -1; // Return next chapter number
+        return (highestChapter >= 0) ? highestChapter + 1 : -1; // Return next chapter number
     }
 }


### PR DESCRIPTION
## Summary
- fix chapter progression when save file only has chapter0

## Testing
- `javac @sources.txt` *(fails: package javafx.* not found)*

------
https://chatgpt.com/codex/tasks/task_e_684490fcbd1c832e85e25b2ae136164b